### PR TITLE
[Feature] Possibility to stream BiqQuery query results.

### DIFF
--- a/modules/bq/src/main/scala/gcp4zio/bq/BQ.scala
+++ b/modules/bq/src/main/scala/gcp4zio/bq/BQ.scala
@@ -3,6 +3,7 @@ package bq
 
 import com.google.cloud.bigquery._
 import zio.{RIO, Task, TaskLayer, ZIO, ZLayer}
+import zio.stream.Stream
 
 trait BQ {
 
@@ -23,6 +24,17 @@ trait BQ {
     * @return
     */
   def fetchResults[T](query: String)(fn: FieldValueList => T): Task[Iterable[T]]
+
+  /** This API can be used to run any SQL(SELECT) query on BigQuery to fetch rows
+    * @param query
+    *   SQL query(SELECT) to execute
+    * @param fn
+    *   function to convert FieldValueList to Scala Type T
+    * @tparam T
+    *   Scala Type for output rows
+    * @return
+    */
+  def fetchStreamingResults[T](query: String)(fn: FieldValueList => T): Task[Stream[Throwable, T]]
 
   /** Load data into BigQuery from GCS
     * @param sourcePath
@@ -112,6 +124,18 @@ object BQ {
     */
   def fetchResults[T](query: String)(fn: FieldValueList => T): RIO[BQ, Iterable[T]] =
     ZIO.environmentWithZIO(_.get.fetchResults[T](query)(fn))
+
+  /** This API can be used to run any SQL(SELECT) query on BigQuery to fetch rows
+    * @param query
+    *   SQL query(SELECT) to execute
+    * @param fn
+    *   function to convert FieldValueList to Scala Type T
+    * @tparam T
+    *   Scala Type for output rows
+    * @return
+    */
+  def fetchStreamingResults[T](query: String)(fn: FieldValueList => T): RIO[BQ, Stream[Throwable, T]] =
+    ZIO.environmentWithZIO(_.get.fetchStreamingResults[T](query)(fn))
 
   /** Load data into BigQuery from GCS
     * @param sourcePath

--- a/modules/bq/src/test/scala/gcp4zio/bq/BQQueryTestSuite.scala
+++ b/modules/bq/src/test/scala/gcp4zio/bq/BQQueryTestSuite.scala
@@ -23,6 +23,22 @@ object BQQueryTestSuite {
           )
         )
       assertZIO(task.foldZIO(ex => ZIO.fail(ex.getMessage), _ => ZIO.succeed("ok")))(equalTo("ok"))
+    },
+    test("Execute Streaming BQ Query ") {
+      val task = BQ.executeQuery("")
+      assertZIO(task.foldZIO(ex => ZIO.fail(ex.getMessage), _ => ZIO.succeed("ok")))(equalTo("ok"))
+    },
+    test("Execute StreamingBQ Query and get data") {
+      val task =
+        BQ.fetchStreamingResults("SELECT * FROM dev.ratings")(rs =>
+          Rating(
+            rs.get("userId").getLongValue,
+            rs.get("movieId").getLongValue,
+            rs.get("rating").getDoubleValue,
+            rs.get("timestamp").getLongValue
+          )
+        )
+      assertZIO(task.foldZIO(ex => ZIO.fail(ex.getMessage), _ => ZIO.succeed("ok")))(equalTo("ok"))
     }
   ) @@ TestAspect.sequential
 }


### PR DESCRIPTION
There is a problem working with medium/big size responses of BQ queries, working with ZStreams it's a good way to handle.
I was necessary because the current implementation of `BQ.fetchResults(fn)` was converting the `TableResult` into a Scala list and converting each element using the standard map function:
``` scala
    val result: TableResult = job.getQueryResults()
    result.iterateAll().asScala.map(fn)
```

This implementation of `BQ.fetchStreamingResults(fn)` transforms the Java stream into `ZStream[Any, Throwable, FieldValueList]` and then applies a` ZPipeline `to execute the `"fn" `passed in the arguments, it's the same behavior but suitable for more data.

``` scala
      val fnTransformer: ZPipeline[Any, Nothing, FieldValueList, T] = ZPipeline.map(fn)
      ZStream.fromJavaStream(job.getQueryResults().streamAll()).via(fnTransformer)
```